### PR TITLE
Added regression test support for macOS

### DIFF
--- a/test/regression/.env
+++ b/test/regression/.env
@@ -1,1 +1,2 @@
 OS_VERSION="3.4.0"
+THREADS=""

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -1,0 +1,10 @@
+# Regression Tests
+
+1. Ensure that the version of OpenStudio you want to run the tests against is installed in the default location
+   1. Windows (e.g. `C:\openstudio-3.4.0`)
+   2. macOS (e.g. `/Applications/OpenStudio-3.4.0`)
+2. Update the `OS_VERSION` variable in the `.env` file to reflect the OpenStudio version
+   1. Optionally set `THREADS` to the number of parallel simulations you want to run, otherwise it will default to the number of cores - 3
+3. In the `test/regression` directory run `npm install` and then `npm start`
+4. View the outputs in `workflows/regression-tests/{OS_VERSION}`
+5. Optionally run `npm run stats` to produce a `test/regression/stats-{OS_VERSION}.csv` file with runtime and success results


### PR DESCRIPTION
This PR includes support for running all regression test gbxmls on macOS, including basic documentation