### PR TITLE
add in a github action to run a subset of gbxml regression test files

### DIFF
--- a/.github/workflows/test_gbxml_with_openstudio.yml
+++ b/.github/workflows/test_gbxml_with_openstudio.yml
@@ -1,0 +1,53 @@
+# This is a basic workflow to help you get started with Actions
+name: test_gbxml_with_openstudio
+
+# trigger action on all branches, pull requests and tags 
+on:
+  pull_request:
+    branches:
+      -  '*'
+  push:
+    branches:
+      -  '*'
+    tags:
+      - '*' 
+
+jobs:
+  test:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    container:
+      image:  nrel/openstudio:3.4.0
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: install node and test
+      shell: bash 
+      run: |
+          echo "installing node v16"
+          curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+          apt update && apt install -y nodejs
+          node -v
+          npm -v
+    - name: install npm dependencies and run tests
+      shell: bash 
+      run: |
+          echo "install dependencies"
+          cd test/regression && npm install 
+          echo "run quick tests" 
+          npm run start_subset
+    - name: run stats, display and check for failures
+      shell: bash 
+      run: |
+          cd test/regression
+          echo "run stats"
+          npm run stats
+          filename=$(ls stats*.csv)
+          cat $filename
+          # Simple check to see if failure in stats file
+          if [ "$(grep -c "Fail" $filename)" -ge 1 ]; then
+            exit 1;
+          fi
+        
+        
+

--- a/test/regression/index.js
+++ b/test/regression/index.js
@@ -8,6 +8,31 @@ import path from 'path';
 
 const threads = Number(process.env.THREADS || Math.max(1, os.cpus().length - 3));
 const osVersion = process.env.OS_VERSION;
+const args = process.argv;
+
+// test only a subset of the xml files. Used for faster feedback on CI.
+// default false
+var subset = false; 
+if (args.length > 2 ) {
+  if (args[2] == 'subset') {
+    console.log('Subset set to true. Only a subset of test files will be ran');
+    subset = true; 
+  }
+}
+
+// List of tests that run < 60 seconds
+const subsetTestFiles = ['3Nordea.xml',
+                         'ExteriorWindowRatioCW.xml',
+                         'Villa.xml',
+                         'Clerestory.xml',
+                         'House.xml',
+                         'Villa Spaces.xml',
+                         'ExteriorWindowRatioWindow.xml',
+                         'Roofs.xml',
+                         'Residential.xml',
+                         '11 Jay St.xml',
+                         '34 Emerson.xml'
+                        ]
 
 if (!osVersion) throw 'OS_VERSION missing from .env file'
 
@@ -26,8 +51,16 @@ const workflows = [];
 for (const {file} of files) {
   await mkdir(`../../workflows/regression-tests/${osVersion}/${file}/`, {recursive: true});
   const workflow = `../../workflows/regression-tests/${osVersion}/${file}/${file.replace(/\.xml/, '')}.osw`;
-  workflows.push(workflow);
+  if(subset) {
+    if (subsetTestFiles.includes(file)) {
+      workflows.push(workflow);
+    }
+  }
+  else {
+    workflows.push(workflow);
+  }
   await writeFile(workflow, osw.replace(/GBXML_INPUT\.xml/g, file));
+  
 }
 
 workflows.forEach(workflow => {
@@ -43,6 +76,10 @@ workflows.forEach(workflow => {
         });
       } else if (process.platform === 'darwin') {
         return execa(`/Applications/OpenStudio-${osVersion}/bin/openstudio`, ['run', '-w', workflow]).catch(() => {
+          console.error(`Error running ${workflow}`);
+        });
+      } else if (process.platform === 'linux') {
+        return execa(`/usr/local/bin/openstudio-${osVersion}`, ['run', '-w', workflow]).catch(() => {
           console.error(`Error running ${workflow}`);
         });
       } else {

--- a/test/regression/package.json
+++ b/test/regression/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
+    "start_subset": "node index.js subset",
     "stats":  "node stats.js"
   },
   "license": "ISC",


### PR DESCRIPTION
resolves #112 

Adding in a GitHub Action to run a subset of tests. Running all of the gbxml as-is using Actions VMs takes over 6 hours and times out. I will try and use the all cores on a CI machine and setup another Action job to run all tests on pushes to master branch. This current set of tests (~11 gbxml) run in about 5 min so this will provide faster feedback for PRs. 

