### PR TITLE
Allow using an abritrary CLI + add default location for Ubuntu + Adjust removed deprecated methods

### DIFF
--- a/measures/gbxml_hvac_import/resources/air_system.rb
+++ b/measures/gbxml_hvac_import/resources/air_system.rb
@@ -197,7 +197,7 @@ class AirSystem < HVACObject
       air_loop_sizing.setZoneMaximumOutdoorAirFraction(1.0)
     else
       air_loop_sizing.setTypeofLoadtoSizeOn('Sensible')
-      air_loop_sizing.setMinimumSystemAirFlowRatio(0.3)
+      air_loop_sizing.setCentralHeatingMaximumSystemAirFlowRatio(0.3)
       air_loop_sizing.setAllOutdoorAirinCooling(false)
       air_loop_sizing.setAllOutdoorAirinHeating(false)
     end

--- a/test/regression/.env
+++ b/test/regression/.env
@@ -1,2 +1,3 @@
 OS_VERSION="3.4.0"
 THREADS=""
+OS_CLI=""

--- a/test/regression/index.js
+++ b/test/regression/index.js
@@ -30,6 +30,11 @@ function getOpenStudioCLI(osVersion) {
 }
 
 const cliPath = getOpenStudioCLI(osVersion);
+if (fs.existsSync(cliPath)) {
+  console.log(`Found OpenStudio CLI at ${cliPath}`);
+} else {
+  throw `Cannot locate CLI for version ${osVersion}, tried ${cliPath}`
+}
 
 const unsortedFiles = fs.readdirSync('../../gbxmls/RegressionTesting', 'utf8');
 const files = [];

--- a/test/regression/index.js
+++ b/test/regression/index.js
@@ -9,7 +9,27 @@ import path from 'path';
 const threads = Number(process.env.THREADS || Math.max(1, os.cpus().length - 3));
 const osVersion = process.env.OS_VERSION;
 
-if (!osVersion) throw 'OS_VERSION missing from .env file'
+if (!osVersion) {
+  throw 'OS_VERSION missing from .env file';
+}
+
+function getOpenStudioCLI(osVersion) {
+  if (process.env.OS_CLI) {
+    return process.env.OS_CLI;
+  }
+
+  if (process.platform === 'win32') {
+    return `C:\\openstudio-${osVersion}\\bin\\openstudio.exe`;
+  } else if (process.platform === 'darwin') {
+    return `/Applications/OpenStudio-${osVersion}/bin/openstudio`;
+  } else if (process.platform === 'linux') {
+    return `/usr/local/openstudio-${osVersion}/bin/openstudio`;
+  }
+
+  throw 'Unsupported OS';
+}
+
+const cliPath = getOpenStudioCLI(osVersion);
 
 const unsortedFiles = fs.readdirSync('../../gbxmls/RegressionTesting', 'utf8');
 const files = [];
@@ -37,17 +57,9 @@ workflows.forEach(workflow => {
     await queue.add(() => {
       start = Date.now();
       console.log(`Start: ${file}`);
-      if (process.platform === 'win32') {
-        return execa(`C:\\openstudio-${osVersion}\\bin\\openstudio.exe`, ['run', '-w', workflow]).catch(() => {
-          console.error(`Error running ${workflow}`);
-        });
-      } else if (process.platform === 'darwin') {
-        return execa(`/Applications/OpenStudio-${osVersion}/bin/openstudio`, ['run', '-w', workflow]).catch(() => {
-          console.error(`Error running ${workflow}`);
-        });
-      } else {
-        throw 'Unsupported OS';
-      }
+      return execa(cliPath, ['run', '-w', workflow]).catch(() => {
+        console.error(`Error running ${workflow} with CLI at ${cliPath}`);
+      });
     });
     const stop = Date.now();
     console.log(`Done: ${file} (${Math.round((stop - start) / 1000)}s)`);


### PR DESCRIPTION
* SizingSystem::setMinimumAirFlowRatio was removed in 3.5.0(alpha), was deprecated since 2.6.2
    *  setCentralHeatingMaximumSystemAirFlowRatio is the replacement. That makes MainOffice.osw in particular run