### PR TITLE
add gbxml postprocess measure

### DIFF
--- a/measures/gbxml_postprocess/README.md
+++ b/measures/gbxml_postprocess/README.md
@@ -1,0 +1,26 @@
+
+
+###### (Automatically generated documentation)
+
+# gbXML Postprocess
+
+## Description
+
+
+## Modeler Description
+
+
+## Measure Type
+ModelMeasure
+
+## Taxonomy
+
+
+## Arguments
+
+
+
+
+This measure does not have any user arguments
+
+

--- a/measures/gbxml_postprocess/README.md.erb
+++ b/measures/gbxml_postprocess/README.md.erb
@@ -1,0 +1,42 @@
+<%#= README.md.erb is used to auto-generate README.md. %>
+<%#= To manually maintain README.md throw away README.md.erb and manually edit README.md %>
+###### (Automatically generated documentation)
+
+# <%= name %>
+
+## Description
+<%= description %>
+
+## Modeler Description
+<%= modelerDescription %>
+
+## Measure Type
+<%= measureType %>
+
+## Taxonomy
+<%= taxonomy %>
+
+## Arguments
+
+<% arguments.each do |argument| %>
+### <%= argument[:display_name] %>
+<%= argument[:description] %>
+**Name:** <%= argument[:name] %>,
+**Type:** <%= argument[:type] %>,
+**Units:** <%= argument[:units] %>,
+**Required:** <%= argument[:required] %>,
+**Model Dependent:** <%= argument[:model_dependent] %>
+<% end %>
+
+<% if arguments.size == 0 %>
+<%= "This measure does not have any user arguments" %>
+<% end %>
+
+<% if outputs.size > 0 %>
+## Outputs
+<% output_names = [] %>
+<% outputs.each do |output| %>
+<% output_names << output[:display_name] %>
+<% end %>
+<%= output_names.join(", ") %>
+<% end %>

--- a/measures/gbxml_postprocess/measure.rb
+++ b/measures/gbxml_postprocess/measure.rb
@@ -1,0 +1,59 @@
+# insert your copyright here
+
+# see the URL below for information on how to write OpenStudio measures
+# http://nrel.github.io/OpenStudio-user-documentation/reference/measure_writing_guide/
+
+# start the measure
+class GbxmlPostprocess < OpenStudio::Measure::ModelMeasure
+  # human readable name
+  def name
+    # Measure name should be the title case of the class name.
+    return 'gbxml postprocess'
+  end
+
+  # human readable description
+  def description
+    return ''
+  end
+
+  # human readable description of modeling approach
+  def modeler_description
+    return ''
+  end
+
+  # define the arguments that the user will input
+  def arguments(model)
+    args = OpenStudio::Measure::OSArgumentVector.new
+
+
+
+    return args
+  end
+
+  # define what happens when the measure is run
+  def run(model, runner, user_arguments)
+    super(model, runner, user_arguments)
+
+    # use the built-in error checking
+    if !runner.validateUserArguments(arguments(model), user_arguments)
+      return false
+    end
+
+    # Set airwall to single pane simple glazing
+    window_simple = OpenStudio::Model::SimpleGlazing.new(model, 3.7642, 0.78)
+    window_simple.setVisibleTransmittance(0.9)
+    window_construction = OpenStudio::Model::Construction.new(model)
+    window_construction.insertLayer(0, window_simple)
+
+    model.getSubSurfaces.each do |sub_surface|
+      if sub_surface.isAirWall
+        sub_surface.setConstruction(window_construction)
+      end
+    end
+
+    return true
+  end
+end
+
+# register the measure to be used by the application
+GbxmlPostprocess.new.registerWithApplication

--- a/measures/gbxml_postprocess/measure.rb
+++ b/measures/gbxml_postprocess/measure.rb
@@ -8,7 +8,7 @@ class GbxmlPostprocess < OpenStudio::Measure::ModelMeasure
   # human readable name
   def name
     # Measure name should be the title case of the class name.
-    return 'gbxml postprocess'
+    return 'gbXML Postprocess'
   end
 
   # human readable description
@@ -44,12 +44,17 @@ class GbxmlPostprocess < OpenStudio::Measure::ModelMeasure
     window_simple.setVisibleTransmittance(0.9)
     window_construction = OpenStudio::Model::Construction.new(model)
     window_construction.insertLayer(0, window_simple)
-
     model.getSubSurfaces.each do |sub_surface|
       if sub_surface.isAirWall
         sub_surface.setConstruction(window_construction)
       end
     end
+
+    # set output objects
+    model.getOutputSQLite.setUnitConversionforTabularData('None')
+    model.getOutputTableSummaryReports.setString(1, 'AllSummaryAndSizingPeriod')
+    model.getOutputControlTableStyle.setColumnSeparator('XMLandHTML')
+    model.getOutputControlTableStyle.setUnitConversion('InchPound') if runner.unitsPreference == 'IP'
 
     return true
   end

--- a/measures/gbxml_postprocess/measure.xml
+++ b/measures/gbxml_postprocess/measure.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <measure>
-  <schema_version>3.1</schema_version>
+  <schema_version>3.0</schema_version>
   <name>gbxml_postprocess</name>
   <uid>305ff045-bf96-46b7-afdc-586779961252</uid>
-  <version_id>df6418e7-7749-424e-8b6e-2dcae9a2628a</version_id>
-  <version_modified>2023-08-18T17:49:57Z</version_modified>
+  <version_id>7d855e06-0c14-4a5c-aec6-c6f1be9dc75d</version_id>
+  <version_modified>20230818T193253Z</version_modified>
   <xml_checksum>FC9586A7</xml_checksum>
   <class_name>GbxmlPostprocess</class_name>
   <display_name>gbXML Postprocess</display_name>
@@ -40,12 +40,6 @@
   </attributes>
   <files>
     <file>
-      <filename>LICENSE.md</filename>
-      <filetype>md</filetype>
-      <usage_type>license</usage_type>
-      <checksum>CD7F5672</checksum>
-    </file>
-    <file>
       <filename>README.md</filename>
       <filetype>md</filetype>
       <usage_type>readme</usage_type>
@@ -56,12 +50,6 @@
       <filetype>erb</filetype>
       <usage_type>readmeerb</usage_type>
       <checksum>703C9964</checksum>
-    </file>
-    <file>
-      <filename>.gitkeep</filename>
-      <filetype>gitkeep</filetype>
-      <usage_type>doc</usage_type>
-      <checksum>00000000</checksum>
     </file>
     <file>
       <version>
@@ -75,16 +63,10 @@
       <checksum>9969B6E4</checksum>
     </file>
     <file>
-      <filename>example_model.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>53D14E69</checksum>
-    </file>
-    <file>
       <filename>gbxml_postprocess_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>EAB60FCC</checksum>
+      <checksum>7411FD25</checksum>
     </file>
   </files>
 </measure>

--- a/measures/gbxml_postprocess/measure.xml
+++ b/measures/gbxml_postprocess/measure.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0"?>
+<measure>
+  <schema_version>3.1</schema_version>
+  <name>gbxml_postprocess</name>
+  <uid>305ff045-bf96-46b7-afdc-586779961252</uid>
+  <version_id>df6418e7-7749-424e-8b6e-2dcae9a2628a</version_id>
+  <version_modified>2023-08-18T17:49:57Z</version_modified>
+  <xml_checksum>FC9586A7</xml_checksum>
+  <class_name>GbxmlPostprocess</class_name>
+  <display_name>gbXML Postprocess</display_name>
+  <description></description>
+  <modeler_description></modeler_description>
+  <arguments />
+  <outputs />
+  <provenances />
+  <tags>
+    <tag>Whole Building.Whole Building Schedules</tag>
+  </tags>
+  <attributes>
+    <attribute>
+      <name>Measure Type</name>
+      <value>ModelMeasure</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Intended Software Tool</name>
+      <value>Apply Measure Now</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Intended Software Tool</name>
+      <value>OpenStudio Application</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Intended Software Tool</name>
+      <value>Parametric Analysis Tool</value>
+      <datatype>string</datatype>
+    </attribute>
+  </attributes>
+  <files>
+    <file>
+      <filename>LICENSE.md</filename>
+      <filetype>md</filetype>
+      <usage_type>license</usage_type>
+      <checksum>CD7F5672</checksum>
+    </file>
+    <file>
+      <filename>README.md</filename>
+      <filetype>md</filetype>
+      <usage_type>readme</usage_type>
+      <checksum>433D5B02</checksum>
+    </file>
+    <file>
+      <filename>README.md.erb</filename>
+      <filetype>erb</filetype>
+      <usage_type>readmeerb</usage_type>
+      <checksum>703C9964</checksum>
+    </file>
+    <file>
+      <filename>.gitkeep</filename>
+      <filetype>gitkeep</filetype>
+      <usage_type>doc</usage_type>
+      <checksum>00000000</checksum>
+    </file>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>3.5.0</identifier>
+        <min_compatible>3.5.0</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>9969B6E4</checksum>
+    </file>
+    <file>
+      <filename>example_model.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>53D14E69</checksum>
+    </file>
+    <file>
+      <filename>gbxml_postprocess_test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>EAB60FCC</checksum>
+    </file>
+  </files>
+</measure>

--- a/measures/gbxml_postprocess/tests/gbxml_postprocess_test.rb
+++ b/measures/gbxml_postprocess/tests/gbxml_postprocess_test.rb
@@ -1,0 +1,49 @@
+# insert your copyright here
+
+require 'fileutils'
+require 'minitest/autorun'
+require 'openstudio'
+require 'openstudio/measure/ShowRunnerOutput'
+require_relative '../measure.rb'
+
+class GbxmlPostprocessTest < Minitest::Test
+
+  def setup
+
+    # make new model
+    @model = OpenStudio::Model::Model.new
+
+    # add objects
+    @model.getOutputSQLite
+    @model.getOutputTableSummaryReports
+    @model.getOutputControlTableStyle
+
+    # create an instance of the measure
+    @measure = GbxmlPostprocess.new
+
+    # create runner with empty OSW
+    @runner = OpenStudio::Measure::OSRunner.new(OpenStudio::WorkflowJSON.new)
+
+    return @model, @measure, @runner
+
+  end
+
+  # def teardown
+  # end
+
+  def test_run
+
+    # run measure
+    arguments_map = OpenStudio::Measure.convertOSArgumentVectorToMap(@measure.arguments(@model))
+    @measure.run(@model, @runner, arguments_map)
+
+    # tests
+    # TODO test subsurface airwall construction
+    assert_equal(@model.getOutputSQLite.unitConversionforTabularData, 'None')
+    assert_equal(@model.getOutputTableSummaryReports.getString(1).to_s, 'AllSummaryAndSizingPeriod')
+    assert_equal(@model.getOutputControlTableStyle.columnSeparator, 'XMLandHTML')
+    assert_equal(@model.getOutputControlTableStyle.unitConversion, 'InchPound')
+
+  end
+
+end


### PR DESCRIPTION
Close #126.

- Requires OpenStudio >=3.5.0, so this can be merged after Autodesk incorporates OpenStudio 3.6.0.
- After this is merged, the `add_xml_output_control_style` and `gbxml_to_openstudio_cleanup` measures should be removed in a separate PR after this is tested.