### PR TITLE
openstudio standards 0.6.1

### DIFF
--- a/measures/advanced_import_gbxml/resources/os_lib_adv_import.rb
+++ b/measures/advanced_import_gbxml/resources/os_lib_adv_import.rb
@@ -272,7 +272,7 @@ module OsLib_AdvImport
 
         # thermostat
         thermal_zones_array.each do |thermal_zone|
-          people_schedule = STANDARD.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
+          people_schedule = OpenstudioStandards::ThermalZone.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
           make_thermostat(thermal_zone, htg_sch, setpoint: htg_setpoint_degC, subtype: 'Heating', people_schedule: people_schedule)
         end
 
@@ -307,7 +307,7 @@ module OsLib_AdvImport
 
         # thermostat
         thermal_zones_array.each do |thermal_zone|
-          people_schedule = STANDARD.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
+          people_schedule = OpenstudioStandards::ThermalZone.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
           make_thermostat(thermal_zone, clg_sch, setpoint: clg_setpoint_degC, subtype: 'Cooling', people_schedule: people_schedule)
         end
 
@@ -396,7 +396,7 @@ module OsLib_AdvImport
 
         # humidistat
         thermal_zones_array.each do |thermal_zone|
-          people_schedule = STANDARD.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
+          people_schedule = OpenstudioStandards::ThermalZone.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
           make_humidstat(thermal_zone, setpoint_schedule, setpoint: setpoint, subtype: 'Humidifying', people_schedule: people_schedule)
         end
 
@@ -431,7 +431,7 @@ module OsLib_AdvImport
 
         # humidistat
         thermal_zones_array.each do |thermal_zone|
-          people_schedule = STANDARD.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
+          people_schedule = OpenstudioStandards::ThermalZone.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
           make_humidstat(thermal_zone, setpoint_schedule, setpoint: setpoint, subtype: 'Humidifying', people_schedule: people_schedule)
         end
 

--- a/measures/advanced_import_gbxml/resources/os_lib_adv_import.rb
+++ b/measures/advanced_import_gbxml/resources/os_lib_adv_import.rb
@@ -41,6 +41,7 @@ require 'date'
 
 # constants for thermostat and humidistat schedules
 STANDARD = Standard.build('90.1-2013')
+STANDARD_VERSION = OpenStudio::VersionString.new(OpenstudioStandards::VERSION)
 FIVE_PCT = 0.05
 
 module OsLib_AdvImport
@@ -272,7 +273,11 @@ module OsLib_AdvImport
 
         # thermostat
         thermal_zones_array.each do |thermal_zone|
-          people_schedule = OpenstudioStandards::ThermalZone.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
+          if STANDARD_VERSION < OpenStudio::VersionString.new('0.6.1')
+            people_schedule = STANDARD.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
+          else
+            people_schedule = OpenstudioStandards::ThermalZone.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
+          end
           make_thermostat(thermal_zone, htg_sch, setpoint: htg_setpoint_degC, subtype: 'Heating', people_schedule: people_schedule)
         end
 
@@ -307,7 +312,11 @@ module OsLib_AdvImport
 
         # thermostat
         thermal_zones_array.each do |thermal_zone|
-          people_schedule = OpenstudioStandards::ThermalZone.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
+          if STANDARD_VERSION < OpenStudio::VersionString.new('0.6.1')
+            people_schedule = STANDARD.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
+          else
+            people_schedule = OpenstudioStandards::ThermalZone.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
+          end
           make_thermostat(thermal_zone, clg_sch, setpoint: clg_setpoint_degC, subtype: 'Cooling', people_schedule: people_schedule)
         end
 
@@ -396,7 +405,11 @@ module OsLib_AdvImport
 
         # humidistat
         thermal_zones_array.each do |thermal_zone|
-          people_schedule = OpenstudioStandards::ThermalZone.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
+          if STANDARD_VERSION < OpenStudio::VersionString.new('0.6.1')
+            people_schedule = STANDARD.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
+          else
+            people_schedule = OpenstudioStandards::ThermalZone.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
+          end
           make_humidstat(thermal_zone, setpoint_schedule, setpoint: setpoint, subtype: 'Humidifying', people_schedule: people_schedule)
         end
 
@@ -431,7 +444,11 @@ module OsLib_AdvImport
 
         # humidistat
         thermal_zones_array.each do |thermal_zone|
-          people_schedule = OpenstudioStandards::ThermalZone.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
+          if STANDARD_VERSION < OpenStudio::VersionString.new('0.6.1')
+            people_schedule = STANDARD.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
+          else
+            people_schedule = OpenstudioStandards::ThermalZone.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
+          end
           make_humidstat(thermal_zone, setpoint_schedule, setpoint: setpoint, subtype: 'Humidifying', people_schedule: people_schedule)
         end
 

--- a/measures/advanced_import_gbxml/resources/os_lib_adv_import.rb
+++ b/measures/advanced_import_gbxml/resources/os_lib_adv_import.rb
@@ -41,7 +41,7 @@ require 'date'
 
 # constants for thermostat and humidistat schedules
 STANDARD = Standard.build('90.1-2013')
-STANDARD_VERSION = OpenStudio::VersionString.new(OpenstudioStandards::VERSION)
+STANDARDS_VERSION = OpenStudio::VersionString.new(OpenstudioStandards::VERSION)
 FIVE_PCT = 0.05
 
 module OsLib_AdvImport
@@ -273,7 +273,7 @@ module OsLib_AdvImport
 
         # thermostat
         thermal_zones_array.each do |thermal_zone|
-          if STANDARD_VERSION < OpenStudio::VersionString.new('0.6.1')
+          if STANDARDS_VERSION < OpenStudio::VersionString.new('0.6.1')
             people_schedule = STANDARD.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
           else
             people_schedule = OpenstudioStandards::ThermalZone.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
@@ -312,7 +312,7 @@ module OsLib_AdvImport
 
         # thermostat
         thermal_zones_array.each do |thermal_zone|
-          if STANDARD_VERSION < OpenStudio::VersionString.new('0.6.1')
+          if STANDARDS_VERSION < OpenStudio::VersionString.new('0.6.1')
             people_schedule = STANDARD.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
           else
             people_schedule = OpenstudioStandards::ThermalZone.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
@@ -405,7 +405,7 @@ module OsLib_AdvImport
 
         # humidistat
         thermal_zones_array.each do |thermal_zone|
-          if STANDARD_VERSION < OpenStudio::VersionString.new('0.6.1')
+          if STANDARDS_VERSION < OpenStudio::VersionString.new('0.6.1')
             people_schedule = STANDARD.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
           else
             people_schedule = OpenstudioStandards::ThermalZone.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
@@ -444,7 +444,7 @@ module OsLib_AdvImport
 
         # humidistat
         thermal_zones_array.each do |thermal_zone|
-          if STANDARD_VERSION < OpenStudio::VersionString.new('0.6.1')
+          if STANDARDS_VERSION < OpenStudio::VersionString.new('0.6.1')
             people_schedule = STANDARD.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)
           else
             people_schedule = OpenstudioStandards::ThermalZone.thermal_zone_get_occupancy_schedule(thermal_zone, occupied_percentage_threshold: FIVE_PCT)


### PR DESCRIPTION
Close #158.

Test with https://github.com/NREL/gbxml-to-openstudio/releases/tag/v1.2.0.rc1, which will fail during the `openstudio_results` measure that will be fixed in another PR. 